### PR TITLE
Add commands for  X Y A B buttons on ROKStar controller

### DIFF
--- a/ROKduinoConstants.h
+++ b/ROKduinoConstants.h
@@ -102,6 +102,11 @@
 #define CMD_XY_MOTOR_COUNTER_CLOCKWISE CMD_MOTOR_3_FORWARD	// X button
 #define CMD_AB_MOTOR_CLOCKWISE CMD_MOTOR_4_BACKWARD			// B button
 #define CMD_AB_MOTOR_COUNTER_CLOCKWISE CMD_MOTOR_4_FORWARD	// A button
+
+#define CMD_Y_BUTTON CMD_MOTOR_3_BACKWARD			// Y button
+#define CMD_X_BUTTON CMD_MOTOR_3_FORWARD	// X button
+#define CMD_B_BUTTON CMD_MOTOR_4_BACKWARD			// B button
+#define CMD_A_BUTTON CMD_MOTOR_4_FORWARD	// A button
  
 #define CMD_TRIM_RIGHT 0x67     // left forefinger + right buttons
 #define CMD_TRIM_LEFT 0x66      // left forefinger + left buttons


### PR DESCRIPTION
Adds commands for the buttons that are on the ROKStar controller.
XY_MOTOR_CLOCKWISE isn't immediately obvious which button on the controller that is associated with. It is good if a command is sent from ROKduino to a MRB, but not necessarily as good if sending commands from the controller to the ROKduino. All the ROKduino sets come with the controller now, so it makes sense to have easily readable commands for the buttons, at least for the labeled buttons. The directional pad is fairly obvious that forward, backward, etc correspond with the Up and Down buttons.
